### PR TITLE
Update Sketch Machine GIPHY profile URL

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -187,7 +187,7 @@
         <br/>
         <br/>
         <div id="fine-print">
-          <a href="https://giphy.com/tv/sketchmachine">Find all the Sketch Machine GIFs on Giphy</a>. The <a href="https://github.com/REAS/sketchmachine" target="_blank">source code</a> for Sketch Machine is on GitHub. For related work, see this informal list of <a href="https://github.com/REAS/sketchmachine/wiki/Weird-Drawing-Software" target="_blank">Weird Drawing Software</a>. Sketch Machine was created with <a href="https://p5js.org/" target="_blank">p5.js</a>.
+          <a href="https://giphy.com/sketchmachine">Find all the Sketch Machine GIFs on Giphy</a>. The <a href="https://github.com/REAS/sketchmachine" target="_blank">source code</a> for Sketch Machine is on GitHub. For related work, see this informal list of <a href="https://github.com/REAS/sketchmachine/wiki/Weird-Drawing-Software" target="_blank">Weird Drawing Software</a>. Sketch Machine was created with <a href="https://p5js.org/" target="_blank">p5.js</a>.
         </div>
         <br>
         <a href="https://giphy.com"><img id="giphy-arts-logo" src="giphy-arts-logo.svg"></a>


### PR DESCRIPTION
The old `tv/` URL does not work:

* ✅ https://giphy.com/sketchmachine
* ❌ https://giphy.com/tv/sketchmachine